### PR TITLE
Add more ConditionVisitor cases (and fix minor bug)

### DIFF
--- a/decompiler/decompiler/condition_visitor.py
+++ b/decompiler/decompiler/condition_visitor.py
@@ -2,7 +2,7 @@ from .bnilvisitor import BNILVisitor
 
 from binaryninja import (Variable, VariableSourceType)
 
-from z3 import (BitVec, And, Or, Not, Solver, simplify, Extract, UGT, ULE, Array, BitVecSort, Concat, Bool)
+from z3 import (BitVec, And, Or, Not, Solver, simplify, Extract, UGT, ULE, UGE, ULT, Array, BitVecSort, Concat, Bool)
 
 def make_variable(var: Variable):
     if var.name == '':
@@ -45,6 +45,11 @@ class ConditionVisitor(BNILVisitor):
 
         return left > right
 
+    def visit_MLIL_CMP_SLT(self, expr):
+        left, right = self.visit_both_sides(expr)
+
+        return left < right
+
     def visit_MLIL_CMP_SGE(self, expr):
         left, right = self.visit_both_sides(expr)
 
@@ -59,6 +64,16 @@ class ConditionVisitor(BNILVisitor):
         left, right = self.visit_both_sides(expr)
 
         return ULE(left, right)
+
+    def visit_MLIL_CMP_UGE(self, expr):
+        left, right = self.visit_both_sides(expr)
+
+        return UGE(left, right)
+
+    def visit_MLIL_CMP_ULT(self, expr):
+        left, right = self.visit_both_sides(expr)
+
+        return ULT(left, right)
 
     def visit_MLIL_LOAD(self, expr):
         src = self.visit(expr.src)

--- a/decompiler/decompiler/linear_mlil.py
+++ b/decompiler/decompiler/linear_mlil.py
@@ -128,7 +128,7 @@ class LinearMLILView(TokenizedTextView):
         to_visit = [
             (n, 0)
             for header, n in sorted(
-                ast._regions.items(), key=cmp_to_key(lambda i, j: 1 if ast.reaching_conditions.get((i[0], j[0])) is None else 1 if i.start > j.start else -1), reverse=True
+                ast._regions.items(), key=cmp_to_key(lambda i, j: 1 if ast.reaching_conditions.get((i[0], j[0])) is None else 1 if i[0].start > j[0].start else -1), reverse=True
             )
         ]
 


### PR DESCRIPTION
Thanks for posting this code Josh!

I threw a couple random binaries I had laying around at it, and tweaked it until they would decompile.

* I've added the remainder of the `MLIL_CMP_*` operations to the `ConditionVisitor`
* Looks like a `[0]` got lost in a refactor, so it was failing on a type error in some cases, I think I've fixed it. No promises it didn't break elsewhere, but works on my machine!

Your stream has been interesting the few times I've been able to watch, hopefully I'll have more time to watch in the future.